### PR TITLE
Fix profile path lookup and optional OpenAI route

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -5,7 +5,14 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from mcp_server.tools.fetch_job_postings import fetch_job_postings
 from mcp_server.tools.resume_rewriter import full_resume_rewriter
-from mcp_server.tools.full_resume_rewriter_openai import full_resume_rewriter as full_resume_rewriter_openai
+try:
+    from mcp_server.tools.full_resume_rewriter_openai import (
+        full_resume_rewriter as full_resume_rewriter_openai,
+    )
+    _openai_available = True
+except ImportError:
+    full_resume_rewriter_openai = None
+    _openai_available = False
 
 app = FastAPI()
 
@@ -26,7 +33,8 @@ async def invoke_resume_rewriter(request: Request):
     data = await request.json()
     return full_resume_rewriter(**data)
 
-@app.post("/tools/full_resume_rewriter_openai/invoke")
-async def invoke_resume_rewriter_openai(request: Request):
-    data = await request.json()
-    return full_resume_rewriter_openai(**data)
+if _openai_available:
+    @app.post("/tools/full_resume_rewriter_openai/invoke")
+    async def invoke_resume_rewriter_openai(request: Request):
+        data = await request.json()
+        return full_resume_rewriter_openai(**data)

--- a/pages/1_Explore_Jobs.py
+++ b/pages/1_Explore_Jobs.py
@@ -1,17 +1,18 @@
 # pages\1_Explore_Jobs.py
 
 import streamlit as st
+import os
 from utils.data_fetcher import call_mcp_tool
 from modules.dashboard_template import display_dashboard
 import json
-import streamlit as st
 from utils.profile_loader import load_user_profile
 
 if "active_profile" not in st.session_state:
     st.warning("Please select a user profile before continuing.")
     st.stop()
 
-profile = load_user_profile(st.session_state["active_profile"])
+profile_name = st.session_state["active_profile"]
+profile = load_user_profile(os.path.join("users", f"{profile_name}.json"))
 
 st.set_page_config(page_title="Job Listings Dashboard", layout="wide")
 st.title("Job Dashboard")

--- a/pages/2_Create_Resume.py
+++ b/pages/2_Create_Resume.py
@@ -14,7 +14,7 @@ if "active_profile" not in st.session_state:
     st.stop()
 
 profile_name = st.session_state["active_profile"]
-profile = load_user_profile(profile_name)
+profile = load_user_profile(os.path.join("users", f"{profile_name}.json"))
 master_resume_path = os.path.join("users", f"{profile_name}_master_resume.csv")
 
 st.set_page_config(page_title="Guided Resume Builder", layout="wide")


### PR DESCRIPTION
## Summary
- load profile JSONs by file path so pages work correctly
- make OpenAI resume route optional in FastAPI server
- mark `utils` as a Python package

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68408dc168e0832d95f059da0864642d